### PR TITLE
it builds and runs the curl successfully, happy cry

### DIFF
--- a/mdv5app/Dockerfile
+++ b/mdv5app/Dockerfile
@@ -1,13 +1,11 @@
-FROM pytorch/torchserve:0.9.0-gpu
+FROM pytorch/torchserve:latest-gpu
 RUN whoami
 RUN ls -la /home/venv/bin/pip
 USER root
 # RUN pip install --upgrade pip && pip install opencv-python ipython
 # commit id https://github.com/ultralytics/yolov5/blob/9286336cb49d577873b2113739788bbe3b90f83c/requirements.txt
 RUN pip install "numpy==1.23.4" "opencv-python==4.6.0.66" \
-    "Pillow==9.2.0" "torchvision" "onnxruntime==1.14.1" "onnx==1.13.1" "tensorrt" "nvgpu"
-RUN pip install https://github.com/pytorch/TensorRT/releases/download/v1.2.0/torch_tensorrt-1.2.0-cp39-cp39-linux_x86_64.whl
-
+    "Pillow==9.2.0" "torchvision" "onnxruntime==1.14.1" "onnx==1.13.1" "tensorrt==10.1.0" "tensorrt-cu12==10.4.0" "torch_tensorrt==2.4.0" "nvgpu"
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh
 RUN mkdir -p /home/model-server/ && mkdir -p /home/model-server/tmp
 WORKDIR /home/model-server

--- a/mdv5app/torchscript_to_tensorrt.py
+++ b/mdv5app/torchscript_to_tensorrt.py
@@ -1,7 +1,7 @@
 import torchvision.transforms as tf
 import torch
 from PIL import Image
-ts_model = torch.jit.load("./model-weights/md_v5a.0.0.960.1280.torchscript")
+ts_model = torch.jit.load("./model-weights/md_v5a.0.0.torchscript")
 
 import torch_tensorrt
 im_placeholder = torch.empty((1, 3, 960, 1280), dtype=torch.float32, device=torch.device("cuda:0"))


### PR DESCRIPTION
torch-tensorrt got out of date and I hadn't pinned it, causing a lotta grief over matching versions. may have also been an issue with the release getting yanked. I couldn't reproduce with the old .mar file. so rebuilt it with new versions of torch and tensorrt that are compatible with CUDA 12.1.This docker image will need the new .mar file to work.

